### PR TITLE
feat: add all-the-icons support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For example, with `use-package`:
 If you are using some other method to install, you will need to ensure the following dependencies:
 
 - `el-patch`
-- `nerd-icons`
+- `nerd-icons` or `all-the-icons`
 - `magit`
 
 ## Nix
@@ -87,9 +87,7 @@ A minimal flake for creating an Emacs with the `magit-file-icons` package could 
 
 # Commentary
 
-This package uses [nerd-icons.el](https://github.com/rainstormstudio/nerd-icons.el) to render icons. Currently, this is the
-only supported icon backend.
+This package uses [nerd-icons.el](https://github.com/rainstormstudio/nerd-icons.el) by default to render icons, but if nerd-icons is not found, it will attempt to use [all-the-icons.el](https://github.com/domtronn/all-the-icons.el) instead. Currently, these are the only supported backends.
 
-The author is not opposed to adding additional icon backends — such as [all-the-icons.el](https://github.com/domtronn/all-the-icons.el)
-or [vscode-icons-emacs](https://github.com/jojojames/vscode-icon-emacs) — in the future.
+The author is not opposed to adding additional icon backends — such as [vscode-icons-emacs](https://github.com/jojojames/vscode-icon-emacs) — in the future.
 

--- a/magit-file-icons.el
+++ b/magit-file-icons.el
@@ -97,7 +97,6 @@ Does not refresh if `magit-file-icons-icon-backend' is nil."
 
 (el-patch-define-template
  (defun magit-diff-insert-file-section)
- (magit-file-icons-refresh-backend)
  (format (el-patch-swap "%-10s %s" "%-10s %s %s") status (el-patch-add (magit-file-icons-icon-for-file-func (or orig file)))
          (if (or (not orig) (equal orig file))
              file
@@ -105,7 +104,6 @@ Does not refresh if `magit-file-icons-icon-backend' is nil."
 
 (el-patch-define-template
  (defun magit-insert-untracked-files)
- (magit-file-icons-refresh-backend)
  (insert
   (propertize
    (el-patch-swap file
@@ -119,7 +117,6 @@ Does not refresh if `magit-file-icons-icon-backend' is nil."
 
 (el-patch-define-template
  (defun magit-diff-wash-diffstat)
- (magit-file-icons-refresh-backend)
  (insert (propertize (el-patch-swap file (format "%s %s" (magit-file-icons-icon-for-file-func file) file)) 'font-lock-face 'magit-filename)
          sep cnt " "))
 
@@ -131,11 +128,17 @@ Does not refresh if `magit-file-icons-icon-backend' is nil."
    (magit-file-icons-mode
     (when magit-file-icons-enable-diff-file-section-icons (el-patch-eval-template #'magit-diff-insert-file-section 'defun))
     (when magit-file-icons-enable-untracked-icons (el-patch-eval-template #'magit-insert-untracked-files 'defun))
-    (when magit-file-icons-enable-diffstat-icons (el-patch-eval-template #'magit-diff-wash-diffstat 'defun)))
+    (when magit-file-icons-enable-diffstat-icons (el-patch-eval-template #'magit-diff-wash-diffstat 'defun))
+    (when magit-file-icons-enable-diff-file-section-icons (magit-file-icons-refresh-backend))
+    (when magit-file-icons-enable-untracked-icons (magit-file-icons-refresh-backend))
+    (when magit-file-icons-enable-diffstat-icons (magit-file-icons-refresh-backend)))
+    (add-hook 'magit-mode-hook 'magit-file-icons-refresh-backend)
    ('deactivate
     (el-patch-unpatch #'magit-diff-insert-file-section 'defun nil)
     (el-patch-unpatch #'magit-insert-untracked-files 'defun nil)
-    (el-patch-unpatch #'magit-diff-wash-diffstat 'defun nil))))
+    (el-patch-unpatch #'magit-diff-wash-diffstat 'defun nil)))
+    (remove-hook 'magit-mode-hook 'magit-file-icons-refresh-backend))
+
 
 (provide 'magit-file-icons)
 

--- a/magit-file-icons.el
+++ b/magit-file-icons.el
@@ -56,7 +56,9 @@
   :group 'magit-file-icons)
 
 (defcustom magit-file-icons-icon-backend 'nerd-icons
-  "Icon backend for magit-file-icons."
+  "Icon backend for magit-file-icons. Set this to nil
+if you want to customize `magit-file-icons-icon-for-file-func'
+or `magit-file-icons-icon-for-dir-func'."
   :type 'symbol
   :group 'magit-file-icons)
 
@@ -66,25 +68,36 @@
                                         (setq magit-file-icons-icon-backend 'all-the-icons))))
 
 (defcustom magit-file-icons-icon-for-file-func nil
-  "Icon for file function."
+  "Icon for file function. Automatically set if
+`magit-file-icons-icon-backend' is non-nil.
+Customize using (fset 'magit-file-icons-icon-for-file-func 'custom-function)."
   :type 'symbol
   :group 'magit-file-icons)
 
 (defcustom magit-file-icons-icon-for-dir-func nil
-  "Icon for directory function."
+  "Icon for directory function. Automatically set if
+`magit-file-icons-icon-backend' is non-nil.
+Customize using (fset 'magit-file-icons-icon-for-file-func 'custom-function)."
   :type 'symbol
   :group 'magit-file-icons)
 
-(if (eq magit-file-icons-icon-backend 'nerd-icons)
-    (funcall (lambda ()
-               (fset 'magit-file-icons-icon-for-file-func 'nerd-icons-icon-for-file)
-               (fset 'magit-file-icons-icon-for-dir-func 'nerd-icons-icon-for-dir)))
-    (funcall (lambda ()
-               (fset 'magit-file-icons-icon-for-file-func 'all-the-icons-icon-for-file)
-               (fset 'magit-file-icons-icon-for-dir-func 'all-the-icons-icon-for-dir))))
+(defun magit-file-icons-refresh-backend ()
+  "Refresh backend according to `magit-file-icons-icon-backend'.
+Does not refresh if `magit-file-icons-icon-backend' is nil."
+  (if magit-file-icons-icon-backend
+  (if (eq magit-file-icons-icon-backend 'nerd-icons)
+      (funcall (lambda ()
+                 (fset 'magit-file-icons-icon-for-file-func 'nerd-icons-icon-for-file)
+                 (fset 'magit-file-icons-icon-for-dir-func 'nerd-icons-icon-for-dir)))
+      (funcall (lambda ()
+                 (fset 'magit-file-icons-icon-for-file-func 'all-the-icons-icon-for-file)
+                 (fset 'magit-file-icons-icon-for-dir-func 'all-the-icons-icon-for-dir))))))
+
+(magit-file-icons-refresh-backend)
 
 (el-patch-define-template
  (defun magit-diff-insert-file-section)
+ (magit-file-icons-refresh-backend)
  (format (el-patch-swap "%-10s %s" "%-10s %s %s") status (el-patch-add (magit-file-icons-icon-for-file-func (or orig file)))
          (if (or (not orig) (equal orig file))
              file
@@ -92,6 +105,7 @@
 
 (el-patch-define-template
  (defun magit-insert-untracked-files)
+ (magit-file-icons-refresh-backend)
  (insert
   (propertize
    (el-patch-swap file
@@ -105,6 +119,7 @@
 
 (el-patch-define-template
  (defun magit-diff-wash-diffstat)
+ (magit-file-icons-refresh-backend)
  (insert (propertize (el-patch-swap file (format "%s %s" (magit-file-icons-icon-for-file-func file) file)) 'font-lock-face 'magit-filename)
          sep cnt " "))
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,3 +1,4 @@
+# TODO add optional argument specifying icon backend (nerd-icons or all-the-icons) and modify packageRequires accordingly
 _: {
   perSystem =
     { lib, pkgs, ... }:


### PR DESCRIPTION
This PR adds all-the-icons support via a new variable `magit-file-icons-icon-backend`.  This defaults to `'nerd-icons`, but is automatically set to `'all-the-icons` as a fallback if nerd-icons isn't installed.  It also abstracts the icon getter functions into `magit-file-icons-icon-for-file-func` and `magit-file-icons-icon-for-dir-func` which can be set as custom function aliases if `magit-file-icons-icon-backend` is set to nil (in order to potentially support icon backends other than nerd-icons or all-the-icons).

I made just a few mistakes as I was debugging so there's some unneeded reversions in some of the commits.  If you'd like me to redo them to be more clean (or fix any other part of it), I'd be happy to.

Also, this is my first PR ever!  I hope its helpful!  Thanks for making this package!
