### PR TITLE
fix!: update for magit-20240624

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715879166,
-        "narHash": "sha256-w07wvE58CcRfROKkfAt+tM72O04mqnsaktDM5rqcD7Y=",
+        "lastModified": 1719450324,
+        "narHash": "sha256-Sym1X1GARJSss3VUrNKwsb12S8qZlGlKxU6RpouSBvk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "753b273b71af6d181b6182ba530e8eb12e5178e9",
+        "rev": "cb0e2cbfad5eedcbe33cc2bff0e83e37e22afa12",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1715668745,
-        "narHash": "sha256-xp62OkRkbUDNUc6VSqH02jB0FbOS+MsfMb7wL1RJOfA=",
+        "lastModified": 1719234068,
+        "narHash": "sha256-1AjSIedDC/aERt24KsCUftLpVppW61S7awfjGe7bMio=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ddcaffecdf098822d944d4147dd8da30b4e6843",
+        "rev": "90bd1b26e23760742fdcb6152369919098f05417",
         "type": "github"
       },
       "original": {

--- a/magit-file-icons.el
+++ b/magit-file-icons.el
@@ -63,7 +63,7 @@
            (format (el-patch-swap "%s -> %s" "%s -> %s %s") orig (el-patch-add (nerd-icons-icon-for-file file)) file))))
 
 (el-patch-define-template
- (defun magit-insert-untracked-files)
+ (defun magit-insert-files-1)
  (insert
   (propertize
    (el-patch-swap file
@@ -87,11 +87,11 @@
   (cond
    (magit-file-icons-mode
     (when magit-file-icons-enable-diff-file-section-icons (el-patch-eval-template #'magit-diff-insert-file-section 'defun))
-    (when magit-file-icons-enable-untracked-icons (el-patch-eval-template #'magit-insert-untracked-files 'defun))
+    (when magit-file-icons-enable-untracked-icons (el-patch-eval-template #'magit-insert-files-1 'defun))
     (when magit-file-icons-enable-diffstat-icons (el-patch-eval-template #'magit-diff-wash-diffstat 'defun)))
    ('deactivate
     (el-patch-unpatch #'magit-diff-insert-file-section 'defun nil)
-    (el-patch-unpatch #'magit-insert-untracked-files 'defun nil)
+    (el-patch-unpatch #'magit-insert-files-1 'defun nil)
     (el-patch-unpatch #'magit-diff-wash-diffstat 'defun nil))))
 
 (provide 'magit-file-icons)


### PR DESCRIPTION
On Jun 24, 2024, `magit-insert-untracked-files` switches to `magit-insert-files` to insert files. The template should update accordingly.