### PR TITLE
feat!: abstract icon getter functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For example, with `use-package`:
   :ensure t
   :after magit
   :init
+  (require 'nerd-icons)
   (magit-file-icons-mode 1)
   :custom
   ;; These are the default values:
@@ -38,12 +39,12 @@ For example, with `use-package`:
 If you are using some other method to install, you will need to ensure the following dependencies:
 
 - `el-patch`
-- `nerd-icons`
 - `magit`
+- Your own icons backend (i.e: `nerd-icons` or `all-the-icons`)
 
 ## Nix
 
-Alternatively, you can use Nix. This repository is a flake and outputs the following packages (versions omitted):
+Alternatively, you can use Nix. Currently, this will install it with the `nerd-icons` backend. This repository is a flake and outputs the following packages (versions omitted):
 
 ```
 └───packages
@@ -88,9 +89,12 @@ A minimal flake for creating an Emacs with the `magit-file-icons` package could 
 
 # Commentary
 
-This package uses [nerd-icons.el](https://github.com/rainstormstudio/nerd-icons.el) to render icons. Currently, this is the
-only supported icon backend.
-
-The author is not opposed to adding additional icon backends — such as [all-the-icons.el](https://github.com/domtronn/all-the-icons.el)
-or [vscode-icons-emacs](https://github.com/jojojames/vscode-icon-emacs) — in the future.
-
+This package by default uses [nerd-icons.el](https://github.com/rainstormstudio/nerd-icons.el) to render icons. A custom icon backend can 
+be used by customizing the `magit-file-icons-icon-for-file-func` and `magit-file-icons-icon-for-dir-func`. A minimal config for [all-the-icons](https://github.com/domtronn/all-the-icons.el) would include:
+```elisp
+(require 'all-the-icons)
+(require 'magit-file-icons)
+(setq magit-file-icons-icon-for-file-func 'all-the-icons-icon-for-file)
+(setq magit-file-icons-icon-for-dir-func 'all-the-icons-icon-for-dir)
+(magit-file-icons-mode 1)
+```

--- a/magit-file-icons.el
+++ b/magit-file-icons.el
@@ -33,7 +33,6 @@
 (require 'el-patch)
 (require 'el-patch-template)
 (require 'magit)
-(require 'nerd-icons)
 
 (defgroup magit-file-icons nil
   "Show file icons in Magit buffers."
@@ -55,12 +54,26 @@
   :type 'boolean
   :group 'magit-file-icons)
 
+(defcustom magit-file-icons-icon-for-file-func 'nerd-icons-icon-for-file
+  "Function to create an icon from a file.
+Set to `nerd-icons-icon-for-file' if using nerd-icons
+and `all-the-icons-icon-for-file' if using all-the-icons."
+  :type 'function
+  :group 'magit-file-icons)
+
+(defcustom magit-file-icons-icon-for-dir-func 'nerd-icons-icon-for-dir
+  "Function to create an icon from a file.
+Set to `nerd-icons-icon-for-dir' if using nerd-icons
+and `all-the-icons-icon-for-dir' if using all-the-icons."
+  :type 'function
+  :group 'magit-file-icons)
+
 (el-patch-define-template
  (defun magit-diff-insert-file-section)
- (format (el-patch-swap "%-10s %s" "%-10s %s %s") status (el-patch-add (nerd-icons-icon-for-file (or orig file)))
+ (format (el-patch-swap "%-10s %s" "%-10s %s %s") status (el-patch-add (funcall magit-file-icons-icon-for-file-func (or orig file)))
          (if (or (not orig) (equal orig file))
              file
-           (format (el-patch-swap "%s -> %s" "%s -> %s %s") orig (el-patch-add (nerd-icons-icon-for-file file)) file))))
+           (format (el-patch-swap "%s -> %s" "%s -> %s %s") orig (el-patch-add (funcall magit-file-icons-icon-for-file-func file)) file))))
 
 (el-patch-define-template
  (defun magit-insert-files-1)
@@ -69,15 +82,15 @@
    (el-patch-swap file
                   (format "%s %s"
                           (if (file-directory-p file)
-                              (nerd-icons-icon-for-dir file)
-                            (nerd-icons-icon-for-file file))
+                              (funcall magit-file-icons-icon-for-dir-func file)
+                            (funcall magit-file-icons-icon-for-file-func file))
                           file))
    'font-lock-face 'magit-filename)
   ?\n))
 
 (el-patch-define-template
  (defun magit-diff-wash-diffstat)
- (insert (propertize (el-patch-swap file (format "%s %s" (nerd-icons-icon-for-file file) file)) 'font-lock-face 'magit-filename)
+ (insert (propertize (el-patch-swap file (format "%s %s" (funcall magit-file-icons-icon-for-file-func file) file)) 'font-lock-face 'magit-filename)
          sep cnt " "))
 
 ;;;###autoload

--- a/magit-file-icons.el
+++ b/magit-file-icons.el
@@ -26,7 +26,10 @@
 
 ;; Places icons next to file entries in Magit buffers based on file extension.
 ;; This is intended to improve visual clarity and ease of gleaning information.
-;; Currently, only the `nerd-icons' backend is supported.
+;; Currently, the `nerd-icons' backend is supported by default if loaded, but
+;; a custom backend (`all-the-icons' or `vscode-icons' for example) can be
+;; used by customizing `magit-file-icons-icon-for-file-func' and
+;; `magit-file-icons-icon-for-dir-func'.
 
 ;;; Code:
 

--- a/test/magit-file-icons-git-repo-tests.el
+++ b/test/magit-file-icons-git-repo-tests.el
@@ -3,6 +3,7 @@
 (require 'ert)
 (require 'el-patch)
 (require 'magit-file-icons)
+(require 'nerd-icons)
 
 (ert-deftest magit-file-icons-test-can-open-magit-status-buffer-while-in-minor-mode ()
   (magit-file-icons-mode +1)


### PR DESCRIPTION
This PR abstracts the icon getter functions into two new variables: `magit-file-icons-icon-for-file-func` and `magit-file-icons-icon-for-dir-func` which will allow the package to support icon backends other than `nerd-icons`.  These functions default to using nerd-icons functions for compatibility, but can be overriden with custom functions from any icon backend.

This removes the dependency on nerd-icons, which will break user config if they are using nerd-icons and have not called `(require 'nerd-icons)` before loading the package.

This also updates the documentation with an example (using `all-the-icons`) and updates the test files so tests can still run.  The tests are only run using nerd-icons, however.

Hopefully this is an improvement over #5, so let me know what you think!  Thanks! 