### PR TITLE
hack: disable icons for untracked files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Display icons for filenames in ![Magit](https://github.com/magit/magit) buffers!
 
 # Changelog
 
+## 3.0.1
+
+Version `3.0.0` contained a bug, and only seemingly fixed the compatibility issue with newer Magit versions.
+
+- Remove icon functionality for untracked files. This is a temporary hack to prevent errors until a working patch can be found.
+
 ## 3.0.0
 
 Version `3.0.0` is a breaking version bump, compatible with `magit` MELPA version `20250203` and greater.

--- a/magit-file-icons.el
+++ b/magit-file-icons.el
@@ -6,7 +6,7 @@
 ;; Created: 14 May 2024
 
 ;; URL: https://github.com/gekoke/magit-file-icons
-;; Package-Version: 3.0.0
+;; Package-Version: 3.0.1
 ;; Package-Requires: ((emacs "24.3") (nerd-icons "0.1.0") (el-patch "3.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -62,12 +62,6 @@
            (format (el-patch-swap "%s -> %s" "%s -> %s %s") orig (el-patch-add (nerd-icons-icon-for-file file)) file))))
 
 (el-patch-define-template
- (defun magit-insert-files)
- (magit-insert-section (file file)
-   (insert (propertize (el-patch-swap file (concat (nerd-icons-icon-for-file file) " ")) 'font-lock-face 'magit-filename))
-   (insert ?\n)))
-
-(el-patch-define-template
  (defun magit-diff-wash-diffstat)
  (insert (propertize (el-patch-swap file (format "%s %s" (nerd-icons-icon-for-file file) file)) 'font-lock-face 'magit-filename)
          sep cnt " "))
@@ -79,11 +73,9 @@
   (cond
    (magit-file-icons-mode
     (when magit-file-icons-enable-diff-file-section-icons (el-patch-eval-template #'magit-diff-insert-file-section 'defun))
-    (when magit-file-icons-enable-untracked-icons (el-patch-eval-template #'magit-insert-files 'defun))
     (when magit-file-icons-enable-diffstat-icons (el-patch-eval-template #'magit-diff-wash-diffstat 'defun)))
    ('deactivate
     (el-patch-unpatch #'magit-diff-insert-file-section 'defun nil)
-    (el-patch-unpatch #'magit-insert-files 'defun nil)
     (el-patch-unpatch #'magit-diff-wash-diffstat 'defun nil))))
 
 (provide 'magit-file-icons)

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -7,7 +7,7 @@ _: {
 
         magit-file-icons = pkgs.emacsPackages.trivialBuild rec {
           pname = "magit-file-icons";
-          version = "v3.0.0";
+          version = "v3.0.1";
 
           src = ../.;
 
@@ -24,11 +24,28 @@ _: {
             pkgs.emacsPackages.magit
           ] ++ packageRequires;
 
-          checkPhase = ''
-            emacs -l package -f package-initialize --batch -l ert -l magit-file-icons.el -l ./test/magit-file-icons-tests.el -f ert-run-tests-batch-and-exit
-            git init
-            emacs -l package -f package-initialize --batch -l ert -l magit-file-icons.el -l ./test/magit-file-icons-git-repo-tests.el -f ert-run-tests-batch-and-exit
-          '';
+          checkPhase =
+            let
+              createGitRepoStateScript = pkgs.writeShellScriptBin "init" ''
+                git init
+                git config user.email "john@example.com"
+                git config user.name "John Doe"
+
+                touch staged.txt unstaged.txt untracked.txt rename.txt
+                git add staged.txt unstaged.txt rename.txt && git commit -m "init"
+
+                mv rename.txt renamed.txt && git add rename.txt renamed.txt && git commit -m "rename"
+
+                echo "staged changes" >> staged.txt && git add staged.txt
+
+                echo "unstaged changes" >> unstaged.txt
+              '';
+            in
+            ''
+              emacs -l package -f package-initialize --batch -l ert -l magit-file-icons.el -l ./test/magit-file-icons-tests.el -f ert-run-tests-batch-and-exit
+              ${createGitRepoStateScript}/bin/init # create staged changes (including file rename) and unstaged changes
+              emacs -l package -f package-initialize --batch -l ert -l magit-file-icons.el -l ./test/magit-file-icons-git-repo-tests.el -f ert-run-tests-batch-and-exit
+            '';
 
           meta = {
             license = lib.licenses.gpl3;

--- a/test/magit-file-icons-git-repo-tests.el
+++ b/test/magit-file-icons-git-repo-tests.el
@@ -24,6 +24,27 @@
   (magit-file-icons-mode 'toggle)
   (magit-file-icons-mode 'toggle))
 
+(ert-deftest magit-file-icons-test-can-toggle-untracked-section ()
+  (magit-file-icons-mode +1)
+  (magit-status)
+  (magit-jump-to-untracked)
+  (magit-section-toggle (magit-current-section))
+  (magit-section-toggle (magit-current-section)))
+
+(ert-deftest magit-file-icons-test-can-toggle-unstaged-section ()
+  (magit-file-icons-mode +1)
+  (magit-status)
+  (magit-jump-to-unstaged)
+  (magit-section-toggle (magit-current-section))
+  (magit-section-toggle (magit-current-section)))
+
+(ert-deftest magit-file-icons-test-can-toggle-staged-section ()
+  (magit-file-icons-mode +1)
+  (magit-status)
+  (magit-jump-to-staged)
+  (magit-section-toggle (magit-current-section))
+  (magit-section-toggle (magit-current-section)))
+
 ;; Local Variables:
 ;; flycheck-disabled-checkers: (emacs-lisp-checkdoc)
 ;; End:


### PR DESCRIPTION
Version `3.0.0` contained a bug, and only seemingly fixed the compatibility issue with newer Magit versions. I've been running into errors and unable to find a working patch.

So remove functionality for untracked icons for the time being.
